### PR TITLE
Range of adjustments icl. ReadMe, Car Jockeys and dealerships

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -34,13 +34,6 @@ Welcome to the **RLS Career Overhaul** mod for BeamNG.drive! This mod enhances v
       - [Online Brand Dealerships](#online-brand-dealerships)
       - [Commercial Vehicle Sales](#commercial-vehicle-sales)
       - [Private Sellers](#private-sellers)
-      - [JDM Imports](#jdm-imports)
-      - [EDM Imports](#edm-imports)
-      - [Other Imports](#other-imports)
-      - [Misc Imports](#misc-imports)
-      - [Rocking Rally](#rocking-rally)
-      - [Clockwise Drag Racing](#clockwise-drag-racing)
-      - [DriftGear Dealer](#driftgear-dealer)
       - [Gizamn's Rod Shop](#gizamns-rod-shop)
       - [TJs Offroad World](#tjs-offroad-world)
       - [Trusted Auto Sales](#trusted-auto-sales)
@@ -98,7 +91,7 @@ Welcome to the **RLS Career Overhaul** mod for BeamNG.drive! This mod enhances v
 
 The **RLS Career Overhaul** mod significantly enhances the career mode experience in BeamNG.drive. It introduces a variety of freeroam events, dynamic police interactions, an improved economy, revamped deliveries, a sophisticated insurance system, expanded garage space, reworked dealerships, and more.
 
-Now, the mod is also **compatible with Italy** (using the Italy Addon). The Italy Addon is available via the Silver Patreon Membership.
+Now, the mod is also **compatible with Italy** (using the Italy Addon). The Italy Addon is available [here](https://github.com/Raceless-RLS/rls_career_overhaul_italy/releases).
 
 ---
 
@@ -128,14 +121,14 @@ Experience an array of new racing events designed to challenge and entertain you
 
   - **Description**: A high-speed drag race along the mud track. Test your vehicle's capabilities in the shallow mud.
   - **Requirements**:
-    - **Target Time**: **8 seconds**
+    - **Target Time**: **9 seconds**
     - **Reward**: **\$1,500**
 
 - **Deep Mud Drag**:
 
   - **Description**: A high-speed drag race along the mud track. Test your vehicle's capabilities in the deep mud. Can you make it through?
   - **Requirements**:
-    - **Target Time**: **12 seconds**
+    - **Target Time**: **15 seconds**
     - **Reward**: **\$2,700**
 
 #### Rally Events
@@ -169,7 +162,6 @@ Experience an array of new racing events designed to challenge and entertain you
     - **Reward**: **\$2,000**
 
 - **Commercial Rally**:
-
   - **Description**: Navigate through commercial areas in a timed rally event. Sharp turns and urban obstacles await.
   - **Requirements**:
     - **Target Time**: **90 seconds**
@@ -230,10 +222,10 @@ Experience an array of new racing events designed to challenge and entertain you
   - **Description**: A challenging circuit with elevation changes and tight corners.
   - **Requirements**:
     - **Standard Lap**:
-      - **Target Time**: **60 seconds**
+      - **Target Time**: **41 seconds**
       - **Reward**: **\$1,250**
     - **Joker Lap**:
-      - **Target Time**: **65 seconds**
+      - **Target Time**: **41 seconds**
       - **Reward**: **\$1,250**
 
 - **King of the Hammer #1**:
@@ -276,6 +268,23 @@ Experience an array of new racing events designed to challenge and entertain you
     - **Target Time**: **25 seconds**
     - **Drift Score**: **3,500**
     - **Reward**: **\$3,000**
+
+- **Redwood Drift**:
+
+  - **Description**: A Drift course in which you navagate the tight twisty roads in the Redwood Forest.
+  - **Requirements**:
+    - **Target Time**: **60 seconds**
+    - **Drift Score**: **6,000**
+    - **Reward**: **\$1,500**
+     - **Note**: Can be done in reverse.
+
+- **Racetrack Drift**:
+
+  - **Description**: A Drift course set in the carpark of the racetrack.
+  - **Requirements**:
+    - **Target Time**: **35 seconds**
+    - **Drift Score**: **4,000**
+    - **Reward**: **\$1,500**
 
 #### Rock Crawl Events
 
@@ -458,7 +467,7 @@ Experience a diverse range of dealerships, each with unique specialties and inve
 - **Specialization**: Cars (no trailers/ATVs/buggies)
 - **Vehicle Requirements**:
   - Factory configurations only
-  - Years 2007-2020+
+  - Years 2002-2020+
   - Various mileage tiers
   - Max value \$65,000
 - **Dealer Fees**: \$749
@@ -496,23 +505,30 @@ Experience a diverse range of dealerships, each with unique specialties and inve
 
 Brand-specific new vehicle dealers:
 
-- **Hirochi Online**:
+- **Soliad Online**:
 
-  - Stock: 15 vehicles
+  - Stock: 10 vehicles
   - New vehicles only
   - Factory configurations
-  - Dealer Fees: \$5,000
+  - Dealer Fees: \$2,500
 
-- **Ibishu Online**:
+- **Gavril Car Online**:
 
-  - Stock: 20 vehicles
+  - Stock: 10 vehicles
   - New vehicles only
   - Factory configurations
-  - Dealer Fees: \$5,000
+  - Dealer Fees: \$2,500
+
+- **Gavril Truck Online**:
+
+  - Stock: 10 vehicles
+  - New vehicles only
+  - Factory configurations
+  - Dealer Fees: \$2,500
 
 - **Soliad Online**:
 
-  - Stock: 15 vehicles
+  - Stock: 10 vehicles
   - New vehicles only
   - Factory configurations
   - Dealer Fees: \$2,500
@@ -525,8 +541,8 @@ All online dealerships feature:
 
 #### Commercial Vehicle Sales
 
-- **Description**: Tractors and Trailers dealership
-- **Stock**: 25 vehicles
+- **Description**: Trucks and various commercial vehicles dealership
+- **Stock**: 20 vehicles
 - **Specialization**:
   - Semi trucks
   - Tanker trucks
@@ -538,70 +554,12 @@ All online dealerships feature:
 
 #### Private Sellers
 
-- **Stock**: 10 vehicles
+- **Stock**: 30 vehicles
 - **Requirements**:
   - Mileage: 15,534-236,121 miles / 25,000-380,000 km
-  - Minimum value: \$450
-  - No trailers or semi trucks
+  - Minimum value: \$950
+  - No trailers, semi trucks or rollers
 - **Features**: No dealer fees
-
-#### JDM Imports
-
-- **Description**: Imported Cars from Asia
-- **Stock**: 10 vehicles
-- **Specialization**: Custom Asian vehicles
-- **Brands**: Ibishu, Hirochi, Arima
-- **Vehicle Types**: High mileage (5.5-164 miles / 8.8-264 km)
-- **Dealer Fees**: \$2,500
-
-#### EDM Imports
-
-- **Description**: Imported Cars from Europe
-- **Stock**: 10 vehicles
-- **Specialization**: Custom European vehicles
-- **Brands**: Civetta, ETK, Cherrier
-- **Vehicle Types**: High mileage (5.5-164 miles / 8.8-264 km)
-- **Dealer Fees**: \$3,500
-
-#### Other Imports
-
-- **Description**: Imported Cars from anywhere else
-- **Stock**: 7 vehicles
-- **Brands**: Autobello, FPU
-- **Vehicle Types**: High mileage (5.5-164 miles / 8.8-264 km)
-- **Dealer Fees**: \$2,000
-
-#### Misc Imports
-
-- **Description**: Modded cars without a price
-- **Stock**: 5 vehicles
-- **Vehicle Types**: High mileage (1,895-559,234 miles / 3,050-900,000 km)
-- **Value Limit**: Under \$100
-- **Dealer Fees**: \$30,000
-
-#### Rocking Rally
-
-- **Description**: Best rally builds around
-- **Stock**: 7 vehicles
-- **Specialization**: Rally configurations
-- **Vehicle Types**: Low-medium mileage (6.8-10.9 miles / 11-17.6 km)
-- **Dealer Fees**: \$1,500
-
-#### Clockwise Drag Racing
-
-- **Description**: Building Drag cars around the clock
-- **Stock**: 7 vehicles
-- **Specialization**: Drag configurations (Auto, Manual, DCT, Sequential)
-- **Vehicle Types**: Low-medium mileage (6.8-10.9 miles / 11-17.6 km)
-- **Dealer Fees**: \$1,500
-
-#### DriftGear Dealer
-
-- **Description**: Pushing the limits of innovation... and tires
-- **Stock**: 7 vehicles
-- **Specialization**: Drift configurations (Auto, Manual, DCT, Sequential)
-- **Vehicle Types**: Low-medium mileage (6.8-10.9 miles / 11-17.6 km)
-- **Dealer Fees**: \$750
 
 #### Gizamn's Rod Shop
 
@@ -609,15 +567,6 @@ All online dealerships feature:
 - **Specialization**: Gizamn custom configurations
 - **Vehicle Types**: Low-medium mileage (6.8-10.9 miles / 11-17.6 km)
 - **Dealer Fees**: \$750
-
-#### TJs Offroad World
-
-- **Description**: The only choice in Offroad from East to West
-- **Stock**: 10 vehicles
-- **Specialization**: ATVs, Buggies, Custom Offroad
-- **Brands**: SP, Trackfab, HelTom Fab, DW
-- **Vehicle Types**: Low-medium mileage (6.8-10.9 miles / 11-17.6 km)
-- **Dealer Fees**: \$1,500
 
 #### Trusted Auto Sales
 
@@ -630,7 +579,7 @@ All online dealerships feature:
 #### Joe's Junk
 
 - **Description**: "You think you hate it now, wait till you drive it"
-- **Stock**: 8 vehicles
+- **Stock**: 7 vehicles
 - **Specialization**: Junk configurations
 - **Vehicle Types**: Very high mileage (158,450-569,174 miles / 255,000-916,000 km)
 - **Dealer Fees**: None
@@ -639,16 +588,16 @@ All online dealerships feature:
 
 - **Description**: Fastest race cars available
 - **Stock**: 10 vehicles
-- **Specialization**: Race configurations
+- **Specialization**: Race, rally, drift offroad and drag configurations
 - **Vehicle Types**: Low-medium mileage (6.8-10.9 miles / 11-17.6 km)
 - **Dealer Fees**: \$2,000
 
 #### Police Dealership
 
 - **Description**: Purchase police vehicles here
-- **Stock**: 10 vehicles
-- **Specialization**: Police vehicles
-- **Dealer Fees**: Not specified
+- **Stock**: 8 vehicles
+- **Specialization**: Pre-Certified Police vehicles
+- **Dealer Fees**: /$500
 
 ---
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -505,13 +505,6 @@ Experience a diverse range of dealerships, each with unique specialties and inve
 
 Brand-specific new vehicle dealers:
 
-- **Soliad Online**:
-
-  - Stock: 10 vehicles
-  - New vehicles only
-  - Factory configurations
-  - Dealer Fees: \$2,500
-
 - **Gavril Car Online**:
 
   - Stock: 10 vehicles

--- a/gameplay/delivery/vehicles.deliveryVehicles.json
+++ b/gameplay/delivery/vehicles.deliveryVehicles.json
@@ -1,15 +1,16 @@
 {
   //tier 1 vehicles
   //junker: bad "old" cars with lots of milage (300k-650k), but often used
+  //Boosted to 250/km to match the reward per km of last generation, blacklisted joesjunk.
   "junkerVehFilter": {
     "type":"vehicle",
     "unlockTag":"junkerVeh",
     "filterName":"Junker Car",
     "baseReward":250,
-    "rewardPerKm":40,
+    "rewardPerKm":250,
     "filter": {
       "whiteList":{"Years": {"min":1900, "max":2005}, "Mileage":{"min":300000000, "max":650000000}, "Value":{"min":2000, "max":50000},"Type":["Car"], "Config Type":["Factory"],"Population":{"min":500}},
-      "blackList":{"Type":["Trailer"]}
+      "blackList":{"Type":["Trailer"], "Config Type":["joesjunk"]}
     },
     "subFilters": [
     ],
@@ -18,12 +19,13 @@
   //tier 2 vehicles
   // TODO: Change this filter to reflect "Transport small vehicles to clients, emphasizing efficiency and the maintenance of vehicle condition."
   //fleet: "default" vehicles from dealership, "relatively" new with lower (35k-150k) mileage, very common.
+  //Boosted to 275/km to match the reward per km of last generation
   "smallVehFilter": {
     "type":"vehicle",
     "unlockTag":"smallVeh",
     "filterName":"Small Car",
     "baseReward":250,
-    "rewardPerKm":52,
+    "rewardPerKm":275,
     "filter": {
       "whiteList":{"Years": {"min":1995, "max":2025}, "Mileage":{"min":35000000, "max":150000000}, "Value":{"min":10000, "max":80000},"Type":["Car"], "Config Type":["Factory"], "Population":{"min":3000}},
       "blackList":{"Type":["Trailer"]}
@@ -33,12 +35,13 @@
     ],
   },
   //police filter only for police vehicles with used (20k-200k) or unused" (0.5k-25k)
+  //Boosted to 300/km to match the reward per km of last generation, base reward 350
   "policeFleetVehFilter": {
     "type":"vehicle",
     "unlockTag":"smallVeh",
     "filterName":"Small Police Car",
-    "baseReward":600,
-    "rewardPerKm":40,
+    "baseReward":350,
+    "rewardPerKm":300,
     "filter": {
       "whiteList":{"Years": {"min":1995, "max":2025}, "Type":["Car"], "Config Type":["Police"]},
       "blackList":{"Type":["Trailer"]}
@@ -55,12 +58,13 @@
   },
 
   //Ambulance Filter used (20k-200k) or unused" (0.5k-25k)
+  //Boosted to 300/km to match the reward per km of last generation, base reward 600
   "ambulanceFleetVehFilter": {
     "type":"vehicle",
     "unlockTag":"smallVeh",
     "filterName":"Ambulance",
     "baseReward":600,
-    "rewardPerKm":40,
+    "rewardPerKm":300,
     "filter": {
       "whiteList":{"Years": {"min":1995, "max":2025}, "Name":["D-Series D45 Ambulance (A)","H-Series H45 Ambulance (A)"]},
       "blackList":{"Type":["Trailer"]}
@@ -79,12 +83,13 @@
   //tier 3 vehicles
   // This is a hardcoded filter that reads a particular property from the info.json: "careerCarJockey"
   // mileage from 80k-500k
+  //Tuned down slightly from .34, but still higher.
   "largeVehFilter": {
     "type":"vehicle",
     "unlockTag":"largeVeh",
     "filterName":"Large Truck",
-    "baseReward":250,
-    "rewardPerKm":92,
+    "baseReward":1500,
+    "rewardPerKm":600,
     "filter": {
       "whiteList" : {"model_key" : ["us_semi"],"Mileage":{"min":80000000, "max":500000000}},
       "blackList":{"hasLoad":[true]},
@@ -96,24 +101,27 @@
 
   //tier 4 vehicles
   //fleet: "default" vehicles from dealership, "relatively" new with lower (5km-80km) mileage, very common. low chance for police or service cars
+  //Base 300, reward per km 250
   "fleetVehFilter": {
     "type":"vehicle",
     "unlockTag":"fleetVeh",
     "filterName":"New Car",
-    "baseReward":250,
-    "rewardPerKm":62,
+    "baseReward":300,
+    "rewardPerKm":250,
     "filter": {
       "whiteList":{"Years": {"min":2000, "max":2025}, "Mileage":{"min":5000, "max":80000}, "Value":{"min":10000, "max":100000},"Type":["Car"], "Config Type":["Factory"], "Population":{"min":300}},
       "blackList":{"Type":["Trailer"]}
     },
   },
   //large vehicles like in tier 3, but "new" (5km-80km)
+  //Base 2500, reward per km 400
+  //Tuned down slightly from .34, but still higher.
   "fleetLargeVehFilter": {
     "type":"vehicle",
     "unlockTag":"fleetVeh",
     "filterName":"New Truck",
-    "baseReward":250,
-    "rewardPerKm":112,
+    "baseReward":2500,
+    "rewardPerKm":400,
     "filter": {
       "whiteList" : {"model_key" : ["us_semi"],"Mileage":{"min":5000, "max":80000}},
       "blackList":{"hasLoad":[true]},
@@ -124,21 +132,24 @@
 
   //tier 5 vehicles
   //customized: non-trivial "Custom"-config-type vehicles with lots of mileage (2k-200k)
+  //blacklisting "joesjunk" just in case, but not sure if it is needed.
+  //Base 800, reward per km 400
   "customizedVehFilter": {
     "type":"vehicle",
     "unlockTag":"exoticVeh",
     "filterName":"Customized Car",
-    "baseReward":300,
-    "rewardPerKm":120,
+    "baseReward":800,
+    "rewardPerKm":400,
     "filter": {
       "whiteList":{"Years": {"min":1950}, "Mileage":{"min":2000000, "max":200000000}, "Value":{"min":30000},"Type":["Car"], "Config Type":["Custom"]},
-      "blackList":{"Type":["Trailer"]}
+      "blackList":{"Type":["Trailer"], "Config Type":["joesjunk"]}
     },
     "subFilters": [
     ],
   },
 
   //exotic: basically "expensive" cars (>90k) with relatively low mileage (10k-50k)
+  //2nd exoticVeh filter?
   "exoticVehFilter": {
     "type":"vehicle",
     "unlockTag":"exoticVeh",

--- a/gameplay/organizations/logistics.organizations.json
+++ b/gameplay/organizations/logistics.organizations.json
@@ -1,3 +1,5 @@
+// Logically, because shuffleboard looks for a specific config, you can just grab another config for a different organization?
+
 {
   "shuffleboardLogistics": {
     "name": "Shuffleboard Logistics",
@@ -122,12 +124,13 @@
     "name": "Jerry Riggs",
     "description": "A small garage and mechanic in the industrial area.",
     "icon": "garage02",
+    
     "reputationLevels": [
-      {},
-      {},
-      {},
-      {},
-      {}
+      {},//-1
+      {},//0
+      {},//1
+      {},//2
+      {}//3
     ]
   },
   "belascoAuto": {

--- a/levels/west_coast_usa/facilities/dealerships.facilities.json
+++ b/levels/west_coast_usa/facilities/dealerships.facilities.json
@@ -10,7 +10,8 @@
 "doors":[["fastAutomotive_area","fastAutomotive_icon", 30]],
 "parkingSpotNames":["fastAutomotiveParking"],
 "activityAcceptProps":[
-  {"keyLabel":"Used Vehicles"}
+  {"keyLabel":"Used Race Cars"},
+  {"keyLabel":"High Performance"}
 ],
 "filter": {
   "blackList":{"Type":["Trailer"],"Config Type":["Frame"]}
@@ -147,7 +148,7 @@
 "doors":[["frameDealership_area","frameDealership_icon", 30]],
 "parkingSpotNames":["frameDealershipParking"],
 "activityAcceptProps":[
-  {"keyLabel":"Used Vehicles"}
+  {"keyLabel":"Rolling Frames"}
 ],
 "filter": {
   "blackList":{"Type":["Trailer"]}
@@ -267,7 +268,7 @@
   "testDrive": {
       "abandonFees" : 300,
       "timeLimit" : 120,
-      "licencePlate" : "prestige"
+      "licencePlate" : "Rich"
   },
   "iconOffsetHeight":1.0,
   "iconLift":0.25,
@@ -284,8 +285,7 @@
   "doors":[["garageDealership_area_1","garageDealership_icon_1", 30]],
   "parkingSpotNames":["garageDealership1", "garageDealership2"],
   "activityAcceptProps":[
-      {"keyLabel":"Used Vehicles"},
-      {"keyLabel":"Low Fees"}
+      {"keyLabel":"Used Trucks and Vans"},
   ],
   "filter": {
       "whiteList":{"Mileage":{"min":8800028, "max":264000845},"Body Style":["Pickup","Van","Chassis Cab"], "Config Type":["Factory"] },
@@ -380,7 +380,7 @@
   "testDrive": {
     "abandonFees" : 250,
     "timeLimit" : 120,
-    "licencePlate" : ""
+    "licencePlate" : "Gizamn"
   },
   "iconOffsetHeight":1.0,
   "iconLift":0.25,
@@ -397,6 +397,9 @@
 "parkingSpotNames":["discountDealershipParking"],
 "activityAcceptProps":[
   {"keyLabel":"Used Vehicles"}
+  {"keyLabel":"No Fees"}
+  {"keyLabel":"High Mileage"}
+
 ],
 "filter": {
 "whiteList":{"Mileage":{"min":305000000, "max":616001971}},
@@ -462,7 +465,7 @@
 "testDrive": {
   "abandonFees" : 250,
   "timeLimit" : 120,
-  "licencePlate" : ""
+  "licencePlate" : "Trusted"
 },
 "iconOffsetHeight":1.0,
 "iconLift":0.25,
@@ -478,7 +481,9 @@
   "doors":[["joesJunk_area","joesJunk_icon", 30]],
   "parkingSpotNames":["joesJunkCar","joesJunkBus"],
   "activityAcceptProps":[
-    {"keyLabel":"Used Vehicles"}
+    {"keyLabel":"VERY Used Vehicles"}
+    {"keyLabel":"VERY High Mileage"}
+    {"keyLabel":"No Fees"}
   ],
   "filter": {
     "blackList":{"Body Style":["ATV","Buggy"], "Config Type":["Frame"]}
@@ -494,7 +499,7 @@
   "testDrive": {
     "abandonFees" : 250,
     "timeLimit" : 120,
-    "licencePlate" : "Joe Junk"
+    "licencePlate" : "JoesJunk"
   },
   "iconOffsetHeight":1.0,
   "iconLift":0.25,
@@ -510,7 +515,7 @@
   "doors":[["policeDealer_area","policeDealer_icon", 30]],
   "parkingSpotNames":["policeDealerParking"],
   "activityAcceptProps":[
-    {"keyLabel":"Used Vehicles"}
+    {"keyLabel":"Certified Police Vehicles"}
   ],
   "filter": {
       "whiteList":{"Mileage":{"min":2000, "max":88000282}, "Config Type":["Police"]},
@@ -563,7 +568,7 @@
   "doors":[["serviceDealer_area","serviceDealer_icon", 30]],
   "parkingSpotNames":["serviceDealerParking"],
   "activityAcceptProps":[
-    {"keyLabel":"Used Vehicles"}
+    {"keyLabel":"Used Service Vehicles"}
   ],
   "filter": {
       "whiteList":{"Mileage":{"min":10000, "max":88000282}, "Config Type":["Service"]},
@@ -625,7 +630,7 @@
   "testDrive": {
     "abandonFees" : 250,
     "timeLimit" : 120,
-    "licencePlate" : "Police"
+    "licencePlate" : "Service"
   },
   "iconOffsetHeight":1.0,
   "iconLift":0.25,
@@ -640,7 +645,7 @@
   "doors":[["trailershop_area","trailershop_icon", 30]],
   "parkingSpotNames":["trailerShop"],
   "activityAcceptProps":[
-    {"keyLabel":"Trucks and Trailers"},
+    {"keyLabel":"Trailers"},
     {"keyLabel":"New & Used"}
   ],
 
@@ -659,7 +664,7 @@
   "testDrive" : {
     "abandonFees" : 100,
     "timeLimit" : 120,
-    "licencePlate" : "belasco"
+    "licencePlate" : "Trailer"
   },
   "iconOffsetHeight":1.0,
   "iconLift":0.25,
@@ -675,7 +680,7 @@
   "doors":[["BruckellDealership_area","BruckellDealership_icon", 30]],
   "parkingSpotNames":["domesticOnline","domesticOnlineBus"],
   "activityAcceptProps":[
-    {"keyLabel":"New Vehicles"}
+    {"keyLabel":"Imported Vehicles"}
   ],
   "filter": {
     "blackList":{"Type":["Trailer"],"Config Type":["Frame"]}
@@ -707,7 +712,7 @@
   "doors":[["GavrilcarDealership_area","GavrilcarDealership_icon", 30]],
   "parkingSpotNames":["domesticOnline","domesticOnlineBus"],
   "activityAcceptProps":[
-    {"keyLabel":"New Vehicles"}
+    {"keyLabel":"Imported Vehicles"}
   ],
   "filter": {
     "blackList":{"Type":["Trailer"],"Config Type":["Frame"]}
@@ -723,7 +728,7 @@
   "testDrive": {
     "abandonFees" : 250,
     "timeLimit" : 120,
-    "licencePlate" : ""
+    "licencePlate" : "Gavril"
   },
   "iconOffsetHeight":1.0,
   "iconLift":0.25,
@@ -739,7 +744,7 @@
   "doors":[["GavriltruckDealership_area","GavriltruckDealership_icon", 30]],
   "parkingSpotNames":["domesticOnline","domesticOnlineBus"],
   "activityAcceptProps":[
-    {"keyLabel":"New Vehicles"}
+    {"keyLabel":"Imported Vehicles"}
   ],
   "filter": {
     "blackList":{"Type":["Trailer"],"Config Type":["Frame"]}
@@ -759,7 +764,7 @@
   "testDrive": {
     "abandonFees" : 250,
     "timeLimit" : 120,
-    "licencePlate" : ""
+    "licencePlate" : "Gavril"
   },
   "iconOffsetHeight":1.0,
   "iconLift":0.25,
@@ -776,7 +781,7 @@
   "doors":[["SoliadDealership_area","SoliadDealership_icon", 30]],
   "parkingSpotNames":["domesticOnline","domesticOnlineBus"],
   "activityAcceptProps":[
-    {"keyLabel":"New Vehicles"}
+    {"keyLabel":"Imported Vehicles"}
   ],
   "filter": {
     "blackList":{"Type":["Trailer"],"Config Type":["Frame"]}
@@ -792,7 +797,7 @@
   "testDrive": {
     "abandonFees" : 250,
     "timeLimit" : 120,
-    "licencePlate" : ""
+    "licencePlate" : "Soliad"
   },
   "iconOffsetHeight":1.0,
   "iconLift":0.25,
@@ -834,7 +839,7 @@
   "testDrive" : {
     "abandonFees" : 100,
     "timeLimit" : 120,
-    "licencePlate" : "belasco"
+    "licencePlate" : "Commercial"
   },
   "iconOffsetHeight":0.24,
   "iconLift":0.24,
@@ -848,7 +853,7 @@
         "stock": 30,
         "filter": {
           "whiteList":{"Mileage":{"min":25000000, "max":380000000}, "Value":{"min":950}},
-          "blackList":{"Type":["Trailer", "Semi Truck"]}
+          "blackList":{"Type":["Trailer", "Semi Truck",],"Config Type":["Frame"]}
         },
         "subFilters": [
           {


### PR DESCRIPTION
Range of adjustments:

Removal of dealerships in the ReadMe.md that were removed in the 0.35 compatibility update
Adding the link to the Italy addon
Adjustments to the requirements of some events to match the mod
Added the Redwood and Racetrack drift tracks
Added the Soliad, Gavril Car and Gavril truck dealerships
Adjustments to stocks in the ReadMe
Boosted the prices of Car Jockeys to pre/close to pre 0.35 prices
Added a few notes to /gameplay/organizations/logistics.organizations.json for later additions
Adjusted keyLabels to the dealerships
Changed default license plates of cars in the dealerships
 
