### PR TITLE
fix(taxi): Do not reset fare streak on rejectJob

### DIFF
--- a/lua/ge/extensions/gameplay/taxi.lua
+++ b/lua/ge/extensions/gameplay/taxi.lua
@@ -898,7 +898,6 @@ local function rejectJob()
     state = "ready"
     currentFare = nil
     core_groundMarkers.resetAll()
-    fareStreak = 0
     jobOfferTimer = 0
     jobOfferInterval = math.random(5, 45)
     dataToSend = {}


### PR DESCRIPTION
The taxi fare streak is being reset to zero when a player rejects a job. This means players cannot decline unwanted fares without losing their streak.

The fare streak should only be reset in `stopTaxiJob()` when a player goes offline, or when they switch vehicles. 