### PR TITLE
Exclude forklift from spawning in traffic

### DIFF
--- a/lua/ge/extensions/overrides/gameplay/traffic/vehicle.lua
+++ b/lua/ge/extensions/overrides/gameplay/traffic/vehicle.lua
@@ -31,7 +31,7 @@ function C:init(id, role)
   local modelData = core_vehicles.getModel(obj.jbeam).model
   local modelType = modelData and string.lower(modelData.Type) or 'none'
   if obj.jbeam == 'unicycle' and obj:isPlayerControlled() then modelType = 'player' end
-  if not modelData or not arrayFindValueIndex({'car', 'truck', 'automation', 'traffic', 'proptraffic', 'player'}, modelType) or obj.ignoreTraffic then
+  if not modelData or not arrayFindValueIndex({'car', 'truck', 'automation', 'traffic', 'proptraffic', 'player'}, modelType) or obj.ignoreTraffic or obj.jbeam == 'TPUMedForklift' then
     log('I', logTag, string.format('Ignoring traffic vehicle due to invalid vehicle type: %d', id))
     return
   end


### PR DESCRIPTION
The TPUMedForklift has Type "Truck" which made it eligible for traffic spawning. Added explicit model exclusion in the traffic vehicle init.