### PR TITLE
Fix taxi timer not pausing with the game

### DIFF
--- a/lua/ge/extensions/gameplay/taxi.lua
+++ b/lua/ge/extensions/gameplay/taxi.lua
@@ -18,6 +18,7 @@ local availableSeats = nil
 local state = "start"
 local timer = 0
 local updateTimer = 1
+local rideElapsed = 0
 local jobOfferTimer = 0
 local jobOfferInterval = math.random(5, 45)
 
@@ -834,7 +835,8 @@ local function calculateSpeedFactor()
     if not currentFare then
         return 0
     end
-    local elapsedTime = os.difftime(os.time(), currentFare.startTime)
+    local elapsedTime = rideElapsed > 0 and rideElapsed or os.difftime(os.time(), currentFare.startTime)
+    if elapsedTime <= 0 then return 0 end
     local actualSpeed = (currentFare.totalDistance or 0) / elapsedTime
 
     return (actualSpeed - suggestedSpeed) / suggestedSpeed
@@ -868,7 +870,7 @@ local function completeRide()
         return
     end
 
-    local elapsedTime = os.difftime(os.time(), currentFare.startTime)
+    local elapsedTime = rideElapsed > 0 and rideElapsed or os.difftime(os.time(), currentFare.startTime)
     local speedFactor = calculateSpeedFactor()
     
     local passengerType = getPassengerType(currentFare.passengerType)
@@ -1072,6 +1074,9 @@ end
 -- UPDATE LOOP
 -- ================================
 local function update(_, dt)
+    if state == "dropoff" then
+        rideElapsed = rideElapsed + dt
+    end
     timer = timer + dt
     if timer < updateTimer then
         return
@@ -1094,6 +1099,7 @@ local function update(_, dt)
             core_groundMarkers.setPath(currentFare.destination.pos, {clearPathOnReachingTarget = true})
             local dropoffDistance = core_groundMarkers.getPathLength()
             currentFare.startTime = os.time()
+            rideElapsed = 0
             currentFare.totalDistance = currentFare.totalDistance + dropoffDistance
             M.rideData = {}
             local taxiDisabled, disabledReason = isTaxiDisabled()


### PR DESCRIPTION
Hey! Noticed that pausing the game mid-taxi-ride eats into your speed bonus since the timer keeps running in the background. This was reported in #198 a while back.

The issue is that `calculateSpeedFactor()` and `completeRide()` use `os.time()`, which is wall-clock time — it doesn't care if the game is paused or not. So if you pause for a few minutes to grab a drink or something, your average speed tanks and you lose your tip.

This PR adds a simple `dt` accumulator during the dropoff phase that respects the simulation pause. Falls back to `os.time()` as a safety net if the accumulator hasn't kicked in yet.

Tested it both ways — without the fix, pausing for ~5 minutes kills the speed bonus. With the fix, pausing has no effect on the calculation.

Fixes #198