### PR TITLE
Fix speed-based tips for Tourist and Luxury passengers

### DIFF
--- a/lua/ge/extensions/gameplay/taxiPassengers/luxury.lua
+++ b/lua/ge/extensions/gameplay/taxiPassengers/luxury.lua
@@ -19,7 +19,7 @@ local luxuryPassenger = {
         local tipBreakdown = {}
         local baseFare = tonumber(fare.baseFare) or 0
         
-        local actualSpeed = (tonumber(fare.totalDistance) or 0) / math.max(1, elapsedTime) * 1000
+        local actualSpeed = (tonumber(fare.totalDistance) or 0) / math.max(1, elapsedTime)
         local suggestedSpeed = 18
         local minSpeed = 2
         

--- a/lua/ge/extensions/gameplay/taxiPassengers/tourist.lua
+++ b/lua/ge/extensions/gameplay/taxiPassengers/tourist.lua
@@ -20,7 +20,7 @@ local function onExtensionLoaded()
             local tipBreakdown = {}
             local baseFare = tonumber(fare.baseFare) or 0
             
-            local actualSpeed = (tonumber(fare.totalDistance) or 0) / math.max(1, elapsedTime) * 1000
+            local actualSpeed = (tonumber(fare.totalDistance) or 0) / math.max(1, elapsedTime)
             local suggestedSpeed = 18
             local minSpeed = 1.5
             


### PR DESCRIPTION
The `actualSpeed` calculation in the Tourist and Luxury tip functions multiplies by 1000, which makes the speed-based tip thresholds impossible to reach. Tips like Scenic Bonus, Perfect Pace, Good Pace (Tourist) and Comfort Bonus, Premium Service (Luxury) can never be earned because of this.

`totalDistance` is already in meters and `elapsedTime` is in seconds, so dividing them already gives m/s ΓÇö which matches `suggestedSpeed = 18`. The `* 1000` just inflates the value way past any threshold.

Tested with both Tourist and Luxury passengers, speed tips now trigger correctly when driving slowly.