### PR TITLE
Fix accidental dismissal of taxi ride summary

### DIFF
--- a/ui-vue-src/modules/career/views/PhoneTaxi.vue
+++ b/ui-vue-src/modules/career/views/PhoneTaxi.vue
@@ -114,7 +114,7 @@
 
             <!-- Complete State -->
             <div class="complete-overlay" v-if="currentState === 'complete'">
-                <div class="complete-modal">
+                <div class="complete-modal" @click.stop>
                     <div class="fare-header">
                         <div class="fare-display center">${{ formatCurrency(totalFare) }}</div>
                         <div class="fare-rating"> ★ {{ passengerRatingDisplay }}</div>


### PR DESCRIPTION
Clicking anywhere on the ride summary modal after completing a taxi fare dismisses it, which is really annoying when you're trying to tap the tip breakdown button and accidentally miss.

The issue is that clicks on the modal bubble up to the `taxi-container`'s `handleBackgroundClick`, which calls `setState('ready')` when in the complete state.

Added `@click.stop` on the `complete-modal` div so clicks inside the summary card stay there. Clicking the backdrop outside the card or the Complete button still dismisses as expected.