### PR TITLE
fix(insurance): accept table-shaped repair costs

### DIFF
--- a/lua/ge/extensions/overrides/career/modules/insurance/insurance.lua
+++ b/lua/ge/extensions/overrides/career/modules/insurance/insurance.lua
@@ -628,11 +628,18 @@ end
 local function makeTestDriveDamageClaim(vehId)
   handleTestDriveEndDamage(vehId)
 end
+local function toMoneyAmount(cost)
+  if type(cost) == "table" then
+    return cost.money or 0
+  end
+  return cost or 0
+end
+
 local function getInsuranceRepairDriverScorePenalty(vehInfo, costs)
   local damageEstimate = career_modules_valueCalculator.getRepairDetails(vehInfo).price
   local deductible = 0
   if type(costs) == "table" then
-    deductible = costs.deductible or 0
+    deductible = toMoneyAmount(costs.deductible)
   end
   local covered = math.max(0, damageEstimate - deductible)
   if covered <= 0 then
@@ -646,7 +653,7 @@ local originComputerId
 local function makeRepairClaim(invVehId, costs, vehInfo)
   local totalCost = 0
   for _, cost in pairs(costs) do
-    totalCost = totalCost + cost
+    totalCost = totalCost + toMoneyAmount(cost)
   end
 
   local insuranceId = invVehs[invVehId].insuranceId or -1
@@ -676,7 +683,7 @@ local function makeRepairClaim(invVehId, costs, vehInfo)
     overrideText = hasUsedAccidentForgiveness and "Use accident forgiveness" or nil,
     other = {
       vehDamagePrice = career_modules_valueCalculator.getRepairDetails(vehInfo).price,
-      deductible = costs.deductible or 0
+      deductible = toMoneyAmount(costs.deductible)
     }
   })
 
@@ -756,7 +763,7 @@ local function startRepair(vehInvId, repairOptionData, callback)
   local totalCost = 0
   if repairOptionData.cost then
     for _, cost in pairs(repairOptionData.cost) do
-      totalCost = totalCost + cost
+      totalCost = totalCost + toMoneyAmount(cost)
     end
   end
 


### PR DESCRIPTION
`missionManager.lua:668` calls `makeRepairClaim(inventoryVehId, {deductible = price}, vehInfo)` with `price = {money = N}` on BeamNG 0.39.4.0. The override sums cost entries as numbers, so it throws:

```
E|GameEngineLua:Exception| [string "lua/ge/extensions/overrides/career/modules/in..."]:654: attempt to perform arithmetic on local 'cost' (a table value)
(2) Lua field 'makeRepairClaim' ... costs = table: {deductible:table {money:1000}}
(3) Lua field 'processTask' at line 668 of chunk 'lua/ge/extensions/gameplay/missions/missionManager.lua'
```

The throw sits in an `onUpdate` hook, so the step repeats every frame and the mission never starts. The money repair and the voucher repair both hit it.

Stock `insurance.lua` accepts a number and a table (0.39.4.0, lines 448-458).

Change: add `toMoneyAmount(cost)` and use it at the four raw reads - the `makeRepairClaim` sum, the `getInsuranceRepairDriverScorePenalty` deductible, the claim history deductible, and the `startRepair` sum. Numeric costs keep the old result. The game pays before it calls `makeRepairClaim`, so only the claim record and the driver score penalty depend on this value.

Tested in game on BeamNG 0.39.4.0 with RLS 2.7.0.2.

Fixes #352
